### PR TITLE
Removed/moved some misplaced tests in the file-http-base group, fixed pathless URL test.

### DIFF
--- a/urls.json
+++ b/urls.json
@@ -125,13 +125,6 @@
           "expect_rel": "file:///C:/foo/bar"
         },
         {
-          "id": "9",
-          "name": "",
-          "base": "http://www.example.com/foo/bar",
-          "rel": "//server/file",
-          "expect_rel": "file://server/file"
-        },
-        {
           "id": "10",
           "name": "",
           "base": "http://www.example.com/foo/bar",
@@ -214,27 +207,6 @@
           "base": "http://www.example.com/foo/bar",
           "rel": "file:c|//foo\\\\bar.html",
           "expect_rel": "file:///c%7C//foo/bar.html"
-        },
-        {
-          "id": "22",
-          "name": "",
-          "base": "http://www.example.com/foo/bar",
-          "rel": "//",
-          "expect_rel": "file:///"
-        },
-        {
-          "id": "23",
-          "name": "",
-          "base": "http://www.example.com/foo/bar",
-          "rel": "///",
-          "expect_rel": "file:///"
-        },
-        {
-          "id": "24",
-          "name": "",
-          "base": "http://www.example.com/foo/bar",
-          "rel": "///test",
-          "expect_rel": "file:///test"
         },
         {
           "id": "25",
@@ -464,7 +436,7 @@
           "id": "1",
           "name": "A pathless URL",
           "url": "http://google.com",
-          "expect_url": "http://google.com"
+          "expect_url": "http://google.com/"
         },
         {
           "id": "2",
@@ -723,6 +695,12 @@
           "name": "",
           "url": "http://@google.com/",
           "expect_url": "http://google.com/"
+        },
+        {
+          "id": "45",
+          "name": "A URL with a pipe character in the hostname.",
+          "url": "http://c|/",
+          "expect_url": "http://c|/"
         }
         ]
       },


### PR DESCRIPTION
Tests 9 and 22-24 of the "file-http-base" appear to have maybe been
intended to test that a relative URL starting with "//" and that has a base
URL with "http:" would for some reason get changed into a "file:" URL. But
that's incorrect. That case is just a normal relative URL case, so
shouldn't be in the "file-http-base" group of cases. And the "relative"
group already has tests for those (48, 50, and 52, I think) with correct
expected results. So I think tests 9 and 22-24 in the "file-http-base"
group can just be dropped.

The existing expected result for test 8 in the "file-http-base" was also
wrong for the same reason, but it had something worth including, which is
that "c|" in a hostname should have an expected result with "c|" as-is.
WebKit at least gets that wrong (changing it to "c%7C"), so it seems like a
case worth retaining. But since that part is really just a host-parsing
test, I simplified it and moved it to the "host" group.

Also, fixed the "pathless URL" test (trailing slash should be appended).
